### PR TITLE
Tweaks to get Summa to compile on *buntu machines

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -40,6 +40,16 @@ ifeq "$(FC)" "gfortran-mp-4.8"
  LIBLAPACK = -L$(LAPK_PATH)/lib -llapack -lblas -latlas
 endif
 
+# gfortran compiler -- needs to be 4.8 or higher
+# default linux locations (*buntu, ...)
+ifeq "$(FC)" "gfortran"
+ NCDF_PATH = /usr
+ LAPK_PATH = /usr
+ # define the lapack libraries
+ LIBLAPACK = -L$(LAPK_PATH)/lib -llapack -lblas -latlas
+endif
+
+
 # Intel fortran compiler
 ifeq "$(FC)" "ifort"
  NCDF_PATH = /opt/netcdf-4.3.0+ifort-12.1
@@ -55,6 +65,11 @@ INCNETCDF = -I$(NCDF_PATH)/include
 # you will need to figure out what the equivalent flags are
 # and may need to update this section
 ifeq "$(FC)" "gfortran-mp-4.8"
+ FLAGS_NOAH = -ffree-form -fdefault-real-8 -ffree-line-length-none -fmax-errors=0 -g -fbacktrace -Wno-unused -Wno-unused-dummy-argument
+ FLAGS_COMM = -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -Wno-unused -Wno-unused-dummy-argument
+ FLAGS_SUMMA = -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -Wno-unused -Wno-unused-dummy-argument
+endif
+ifeq "$(FC)" "gfortran"
  FLAGS_NOAH = -ffree-form -fdefault-real-8 -ffree-line-length-none -fmax-errors=0 -g -fbacktrace -Wno-unused -Wno-unused-dummy-argument
  FLAGS_COMM = -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -Wno-unused -Wno-unused-dummy-argument
  FLAGS_SUMMA = -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -Wno-unused -Wno-unused-dummy-argument

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,8 @@ We have successfully installed SUMMA on a number of Unix-like (*nix) operating s
 
  * the LAPACK — Linear Algebra PACKage library. [LAPACK](http://www.netlib.org/lapack/) provides a series of routines for linear algebra operations, including matrix solvers. How to install the library depends on your *nix variant and is not covered here. For example, on OS X you will get all the necessary LAPACK routines by installing the ATLAS software (again, this is easiest using a package manager; note that ATLAS can take many hours to build the first time when you install it).
 
+ * The [ATLAS](http://math-atlas.sourceforge.net/) (Automatically Tuned Linear Algebra Software) library.
+
  * a copy of the SUMMA source code from [this repo](https://github.com/UCAR/summa). You have a number of options:
 
     * If you just want to use the latest stable release of SUMMA, then simply look for the most recent tag;


### PR DESCRIPTION
Default settings for a vanilla debian/ubuntu style install (only requries the user to input "gfortran" as the FC, without specifying a version).

Also, a note in the readme about the atlas requirement.